### PR TITLE
Remove cyhy module dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.python-version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-# The following line refers to a private repository, so it requires a
-# GitHub token for installation
-# https://github.com/jsf9k/cyhy-core/tarball/develop
-dateutil
 docopt
+python-dateutil
+https://github.com/cisagov/mongo-db-from-config/tarball/develop

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 docopt
-python-dateutil
 https://github.com/cisagov/mongo-db-from-config/tarball/develop
+python-dateutil

--- a/rva_pusher2.py
+++ b/rva_pusher2.py
@@ -2,21 +2,20 @@
 '''Translate exported data from JIRA to MongoDB.
 
 Usage:
-  rva_data_manager.py [--section SECTION] [FILTER]
+  rva_data_manager.py DB_CONFIG_FILE [FILTER]
   rva_data_manager.py (-h | --help)
   rva_data_manager.py --version
 
 Options:
   -h --help                      Show this screen.
   --version                      Show version.
-  -s SECTION --section=SECTION   Configuration section to use.
 '''
 
 import csv
 import re
 import subprocess
 
-from cyhy.db import database
+from mongo_db_from_config import db_from_config
 import dateutil.parser
 from docopt import docopt
 
@@ -154,7 +153,7 @@ def main():
     global __doc__
     __doc__ = re.sub('COMMAND_NAME', __file__, __doc__)
     args = docopt(__doc__, version='v0.0.1')
-    db = database.db_from_config(args['--section'])
+    db = db_from_config(args['DB_CONFIG_FILE'])
 
     grab_csv_from_jira(args['FILTER'])
     prep_and_import_csv(db)


### PR DESCRIPTION
This PR removes the dependency on the private repo cyhy_core module (resolves issue #4) and instead uses [our new public package](https://github.com/cisagov/mongo-db-from-config) to create the Mongo DB connection.

**IMPORTANT:** This PR also changes the format used to define the database credentials; you will need to update your config file to use this syntax:
```
database:
  uri: mongodb://username:password@localhost:27017/auth-db-name
  name: db-name
```
Note that the notion of "sections" in the DB config file is no longer supported here. If you want to use a different set of DB credentials, use a different DB config file.