### PR TITLE
Fix "CI Type" and "CI Systems" Having Reversed Data Types

### DIFF
--- a/src/ade/assessment_data_export.py
+++ b/src/ade/assessment_data_export.py
@@ -164,7 +164,7 @@ def convert_xml_to_json(xml_filename, output_filename):
 
     # Iterate through XML data and build JSON data
     for assessment in assessment_data:
-        assessment_json = {"Requested Services": [], "Operators": [], "CI Type": []}
+        assessment_json = {"Requested Services": [], "Operators": []}
 
         # Grab data from key required fields
         for field in ("summary", "created", "updated", "status"):
@@ -184,6 +184,9 @@ def convert_xml_to_json(xml_filename, output_filename):
             # Make the Assessment ID our primary id
             if key == "Asmt ID":
                 assessment_json["id"] = custom_field_values.get("$")
+            # Build the list of CI Systems
+            elif key == "CI Systems":
+                assessment_json[key] = field_values_to_list(custom_field_values)
             # Turn Election value into a true boolean
             elif key == "Election":
                 value = custom_field_values.get("$")
@@ -193,6 +196,9 @@ def convert_xml_to_json(xml_filename, output_filename):
                     assessment_json["Election"] = False
                 else:
                     assessment_json["Election"] = None
+            # Build the list of Operators
+            elif operator_regex.match(key):
+                assessment_json["Operators"].append(custom_field_values.get("$"))
             # Gobble up POC info; we don't want to pass it on
             elif key in ["POC Name", "POC Email", "POC Phone"]:
                 assessment_json[key] = None
@@ -207,14 +213,6 @@ def convert_xml_to_json(xml_filename, output_filename):
                     # There are multiple requested services
                     for service in custom_field_values:
                         assessment_json["Requested Services"].append(service.get("$"))
-            # Build the list of Operators
-            elif operator_regex.match(key):
-                assessment_json["Operators"].append(custom_field_values.get("$"))
-            # Build the list of CI Types
-            elif key == "CI Type":
-                assessment_json["CI Type"] = [
-                    i.strip() for i in custom_field_values.get("$").split(",")
-                ]
             elif key == "Testing Phase":
                 assessment_json[key] = field_values_to_list(custom_field_values)
             else:


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This fixes the `CI Type` and `CI System` fields having flipped data types so that they match what's in the [`assessment` database](https://github.com/cisagov/ncats-data-dictionary#assessment-database). In the database the `ci_type` field is currently stored as a list and the `ci_systems` field is a string. The opposite is what is defined in the dictionary. This PR fixes the JSON generation, but a separate script will need to be run to fix existing data.

The key comparisons have also been rearranged into alphabetical order to improve readability.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
When converting the `Testing Phase` field to a multiselect in #14 I noticed that these two fields did not match what is listed in the [data dictionary](https://github.com/cisagov/ncats-data-dictionary#assessment-database).
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I tested this against a sample xml to ensure expected output.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
